### PR TITLE
added ability to add cookiecontainer in webrequest. fixed and bumped ver...

### DIFF
--- a/PainlessHttp.Tests/Utils/ClientUtilsTests.cs
+++ b/PainlessHttp.Tests/Utils/ClientUtilsTests.cs
@@ -12,7 +12,7 @@ namespace PainlessHttp.Tests.Utils
 			public void ShouldReturnExpectedAgentName()
 			{
 				/* Setup */
-				const string version = "0.10.1.0";
+				const string version = "0.11.5.0";
 				var expected = string.Format("Painless Http Client {0}", version);
 				/* Test */
 				var agent = ClientUtils.GetUserAgent();

--- a/PainlessHttp/Client/Configuration.cs
+++ b/PainlessHttp/Client/Configuration.cs
@@ -44,7 +44,7 @@ namespace PainlessHttp.Client
 			/// Action to be made on the underlying WebRequest before it is sent.
 			/// E.g. request => request.Headers.Add("X-Additional-Header", "Additional Value")
 			/// </summary>
-			public Action<WebRequest> WebrequestModifier { get; set; }
+			public Action<HttpWebRequest> WebrequestModifier { get; set; }
 			public NetworkCredential Credentials { get; set; }
 
 			public AdvancedConfiguration()

--- a/PainlessHttp/Properties/AssemblyInfo.cs
+++ b/PainlessHttp/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.11.4")]
-[assembly: AssemblyFileVersion("0.11.4")]
+[assembly: AssemblyVersion("0.11.5")]
+[assembly: AssemblyFileVersion("0.11.5")]


### PR DESCRIPTION
...sion

Example:

```
        var visitedCookie = new Cookie("IAR", "visited") { Domain = url.Host };

        var cookieContainer = new System.Net.CookieContainer();
        cookieContainer.Add(visitedCookie);

        var config = new Configuration
        {
            BaseUrl = url.AbsoluteUri,
            Advanced =
            {
                RequestTimeout = new TimeSpan(days: 0, hours: 0, minutes: 0, seconds: 60),
                ContentNegotiation = true,
                WebrequestModifier = request =>
                {
                    request.CookieContainer = cookieContainer;
                },        
            }
        };
        _httpClient = new PainlessHttp.Client.HttpClient(config);
```
